### PR TITLE
Remove unused Head import

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import Head from 'next/head'
-
 export default function Home() {
   return (
     <div className="container flex items-center p-4 mx-auto min-h-screen justify-center">


### PR DESCRIPTION
The `index.tsx` page includes an unused `Head` import:

```js
import Head from 'next/head'
```

Removing to clean up the code.